### PR TITLE
fix: bump `quickcheck` from `0.9` to `1.0` (#125)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ scale-codec = ["parity-scale-codec", "multihash/scale-codec"]
 serde-codec = ["alloc", "serde", "multihash/serde-codec", "serde_bytes"]
 
 [dependencies]
-multihash = { version = "0.16.2", default-features = false }
+multihash = { version = "0.17.0", default-features = false }
 unsigned-varint = { version = "0.7.0", default-features = false }
 
 multibase = { version = "0.9.1", optional = true, default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive"], optional = true }
-quickcheck = { version = "0.9.2", optional = true }
-rand = { version = "0.7.3", optional = true }
+quickcheck = { version = "1.0", optional = true }
+rand = { version = "0.7.3", optional = true, features = ["small_rng"]}
 serde = { version = "1.0.116", default-features = false, optional = true }
 serde_bytes = { version = "0.11.5", optional = true }
 arbitrary = { version = "1.1.0", optional = true }


### PR DESCRIPTION
Update quickcheck to 1.0.

BREAKING CHANGE: quickcheck 1.0 has a different API

The API for arbitraries changed in quickcheck v1.0, hence this is a breaking change.

Co-authored-by: David Himmelstrup <lemmih@gmail.com>
Co-authored-by: tyshkor <tyshko1@gmail.com>